### PR TITLE
changing repo name to custom-formatter

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
     docker:
       - image: circleci/node:10.14
     
-    working_directory: ~/formatted-input
+    working_directory: ~/custom-formatter
     steps:
       - checkout
       - restore_cache:
@@ -22,7 +22,7 @@ jobs:
     docker:
       - image: circleci/node:10.14
     
-    working_directory: ~/formatted-input
+    working_directory: ~/custom-formatter
     steps:
       - checkout
       - run: yarn install

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -55,7 +55,7 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at opensource@thecitybase.com. All
+reported by contacting the project team at <opensource@thecitybase.com>. All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -6,7 +6,7 @@ A brief description of the changes and purpose of the PR.
 - [x] ...
 
 ## Code of Conduct
-https://github.com/CityBaseInc/formatted-input/blob/master/CODE_OF_CONDUCT.md
+https://github.com/CityBaseInc/custom-formatter/blob/master/CODE_OF_CONDUCT.md
 
 ## Concerns
 (optional)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## What?
 
-FormattedInput is a small component library which will allow you to design a custom input format and apply it to a form field. No matter the type of formatting your form needs, you are able to customize what type of format the input takes and the symbols being used in between the characters or digits.
+Custom-Formatter is a small component library which will allow you to design a custom input format and apply it to a form field. No matter the type of formatting your form needs, you are able to customize what type of format the input takes and the symbols being used in between the characters or digits.
 
 The component at the center of the library is FormattedInput, which like the basic input element, is a [controlled component](https://reactjs.org/docs/forms.html#controlled-components), which means that the React component utilizing it is the source of truth for its value.
 
@@ -12,14 +12,14 @@ FormattedInput is purely a cosmetic UI component, meaning that the raw value of 
 
 ## Why?
 
-FormattedInput provides the designer with as much control as possible. There are similar packages with more specific contexts (for example, inputs designed to format currency). By requiring each format to be specifically designed, the developer has full control over how the addition of each new character affects the format. See the phone format example below for how adding two characters at the end will affect the placement of characters at the beginning.
+Custom-Formatter provides the designer with as much control as possible. There are similar packages with more specific contexts (for example, inputs designed to format currency). By requiring each format to be specifically designed, the developer has full control over how the addition of each new character affects the format. See the phone format example below for how adding two characters at the end will affect the placement of characters at the beginning.
 
 ## Creating a Formatter
 
-FormattedInput exposes a `createFormat` function to allow you complete control over what formats the user's input can take (in order). You supply an array of string formats which will be applied to the user's input by swapping out the placeholder character (of your choosing) for the actual value.
+Custom-Formatter exposes a `createFormat` function to allow you complete control over what formats the user's input can take (in order). You supply an array of string formats which will be applied to the user's input by swapping out the placeholder character (of your choosing) for the actual value.
 
 ```javascript
-import { createFormat } from "formatted-input";
+import { createFormat } from "custom-formatter";
 const phoneFormats = [
   "",
   "+_",
@@ -46,7 +46,7 @@ Check the `/examples` folder for a runnable demonstration.
 
 ```javascript
 import React, { useState } from "react";
-import FormattedInput, { createFormat } from "formatted-input";
+import { FormattedInput, createFormat } from "custom-formatter";
 
 const dateFormats = [
   "",

--- a/examples/ExampleForm/exampleForm.js
+++ b/examples/ExampleForm/exampleForm.js
@@ -1,5 +1,5 @@
 import React, { useState } from "../../node_modules/react";
-import FormattedInput, { createFormat } from "../../src/FormattedInput";
+import { createFormat, FormattedInput } from "../../src";
 
 const phoneFormats = [
   "",

--- a/examples/ReduxFreeformExample/reduxFreeformExample.js
+++ b/examples/ReduxFreeformExample/reduxFreeformExample.js
@@ -1,5 +1,5 @@
 import React from "../../node_modules/react";
-import FormattedInput, { createFormat } from "../../src/FormattedInput";
+import { FormattedInput, createFormat } from "../../src";
 import {
   required,
   matchesField,

--- a/examples/package.json
+++ b/examples/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "formatting-input",
+  "name": "custom-formatter",
   "version": "1.0.0",
-  "description": "Example of building a form using formatting-input",
+  "description": "Example of building a form using custom-formatter",
   "main": "index.js",
-  "author": "Citybase Inc",
+  "author": "Citybase Inc. <opensource@thecitybase.com>",
   "license": "MIT",
   "scripts": {
     "start": "parcel index.html",

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "formatted-input",
+  "name": "custom-formatter",
   "version": "1.0.0",
   "main": "src/index.js",
-  "repository": "git@github.com:CityBaseInc/formatted-input.git",
-  "author": "Citybase Inc.",
+  "repository": "git@github.com:CityBaseInc/custom-formatter.git",
+  "author": "Citybase Inc. <opensource@thecitybase.com>",
   "license": "MIT",
-  "browser": "dist/formatted-input.e31bb0bc.js",
+  "browser": "dist/custom-formatter.e31bb0bc.js",
   "dependencies": {
     "babel-loader": "8.0.5",
     "react": "^16.9.0",

--- a/test/createFormat.test.js
+++ b/test/createFormat.test.js
@@ -1,5 +1,5 @@
 import test from 'ava';
-import { createFormat } from '../src/FormattedInput';
+import { createFormat } from '../src';
 import { phoneFormats, dateFormats } from "./utils";
 
 test("creates a formatter correctly", t => {

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -1,7 +1,7 @@
 import test from "ava";
 import React, { useState } from "react";
 import { shallow, mount } from "enzyme";
-import FormattedInput, { createFormat } from "../src/FormattedInput";
+import { FormattedInput, createFormat } from "../src";
 import Enzyme from "enzyme";
 import Adapter from 'enzyme-adapter-react-16';
 import { dateFormats, phoneFormats } from "./utils";


### PR DESCRIPTION
## Description
Changing package name to custom-formatter, but leaving component name as FormattedInput

## Changes
- [x] updating repo name and docs
- [x] add CB open source email

## Code of Conduct
https://github.com/CityBaseInc/formatted-input/blob/master/CODE_OF_CONDUCT.md
