### PR TITLE
fixing bug in some browsers where last FI on page steals focus

### DIFF
--- a/src/FormattedInput.js
+++ b/src/FormattedInput.js
@@ -25,7 +25,7 @@ const FormattedInput = ({ value, formatter, onChange, ...props }) => {
   });
   useLayoutEffect(() => {
     // A lot of the work here is cursor manipulation
-    if (inputEl.current) {
+    if (inputEl.current && inputEl.current === document.activeElement) {
       inputEl.current.setSelectionRange(
         state.selectionStart,
         state.selectionEnd

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -166,9 +166,11 @@ test("cursor position", t => {
   let form = mount(<TestForm formats={phoneFormats} char={"_"} />);
   let formattedInput = form.find("FormattedInput").at(0);
   let input = form.find("input").first();
+  input.instance().focus();
   t.is(input.instance().selectionStart, 0);
   t.is(input.instance().selectionEnd, 0);
   formattedInput.simulate("change", {target: {value: "12345678900"}});
+  input.instance().focus();
   input = form.find("input").first();
   t.is(input.instance().selectionStart, 19);
   t.is(input.instance().selectionEnd, 19);


### PR DESCRIPTION
## Description
Bug in Safari and Edge causes the last Formatted Input on a page to steal focus.

## Changes
- [x] add check to useLayoutEffect callback to make sure that input has focus

## Code of Conduct
https://github.com/CityBaseInc/formatted-input/blob/master/CODE_OF_CONDUCT.md
