### PR TITLE
Fix Chrome mobile autofill of FormattedInput

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,16 +1,13 @@
 {
   "name": "formatted-input",
-  "version": "1.1.0-beta.0",
+  "version": "1.1.0",
   "main": "dist/formatted-input.cjs.js",
   "module": "dist/formatted-input.esm.js",
   "browser": "dist/formatted-input.umd.js",
   "repository": "https://github.com/CityBaseInc/formatted-input",
   "author": "Citybase Inc. <opensource@thecitybase.com>",
   "license": "MIT",
-  "files": [
-    "src",
-    "dist"
-  ],
+  "files": ["src", "dist"],
   "peerDependencies": {
     "react": "^16.9.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,13 +1,16 @@
 {
   "name": "formatted-input",
-  "version": "0.1.1",
+  "version": "1.1.0-beta.0",
   "main": "dist/formatted-input.cjs.js",
   "module": "dist/formatted-input.esm.js",
   "browser": "dist/formatted-input.umd.js",
   "repository": "https://github.com/CityBaseInc/formatted-input",
   "author": "Citybase Inc. <opensource@thecitybase.com>",
   "license": "MIT",
-  "files": ["src", "dist"],
+  "files": [
+    "src",
+    "dist"
+  ],
   "peerDependencies": {
     "react": "^16.9.0"
   },

--- a/src/FormattedInput.js
+++ b/src/FormattedInput.js
@@ -35,6 +35,11 @@ const FormattedInput = ({ value, formatter, onChange, ...props }) => {
     }
   });
   const handleChange = (event) => {
+    const deleteKeyPressed = stateRefs.current.isDelete;
+    const maxFormatExceeded = stateRefs.current.rawValue.length >= formatter.formats.length - 1;
+    if (maxFormatExceeded && !deleteKeyPressed) {
+      return;
+    }
     /* At the beginning of onChange, event.target.value is a concat of the previous formatted value
     * and an unformatted injection at the start, end, or in the middle (maybe a deletion). To prepare 
     * the unformatted value for the user's onChange, the formatted string and unformatted injection need
@@ -73,7 +78,6 @@ const FormattedInput = ({ value, formatter, onChange, ...props }) => {
 
     // Edit the previous unformatted value (either add, update or delete)
     const injectIntoOldValue = inject(unformattedOldValue);
-    const deleteKeyPressed = stateRefs.current.isDelete;
     const unformattedNewValue = deleteKeyPressed
       ? rawInjectionPointStart === rawInjectionPointEnd
         ? injectIntoOldValue(
@@ -116,11 +120,12 @@ const FormattedInput = ({ value, formatter, onChange, ...props }) => {
           ? stateRefs.current.selectionStart
           : stateRefs.current.selectionEnd;
 
+    const formattedNewValue = format(formatter)(unformattedNewValue);
     setState({
       selectionStart: newFormattedCursorPosition,
       selectionEnd: newFormattedCursorPosition,
       rawValue: unformattedNewValue,
-      formattedValue: format(formatter)(unformattedNewValue),
+      formattedValue: formattedNewValue,
     });
     // Apply the external onChange function to the raw underlying string
     // This is where the user generally updates the input value

--- a/src/FormattedInput.js
+++ b/src/FormattedInput.js
@@ -15,10 +15,8 @@ export const createFormat = (formats, formatChar) => ({
 });
 
 const FormattedInput = ({ value, formatter, onChange, ...props }) => {
+  const [formattedValue, setFormattedValue] = useState(format(formatter)(value));
   const inputEl = useRef(null);
-  const [state, setState] = useState({
-    formattedValue: format(formatter)(value)
-  });
   const stateRefs = useRef({
     selectionStart: 0,
     selectionEnd: 0,
@@ -29,11 +27,11 @@ const FormattedInput = ({ value, formatter, onChange, ...props }) => {
     // A lot of the work here is cursor manipulation
     if (inputEl.current && inputEl.current === document.activeElement) {
       inputEl.current.setSelectionRange(
-        state.selectionStart,
-        state.selectionEnd
+        stateRefs.current.selectionStart,
+        stateRefs.current.selectionEnd
       );
     }
-  });
+  }, [stateRefs]);
   const handleChange = (event) => {
     const deleteKeyPressed = stateRefs.current.isDelete;
     const maxFormatExceeded = stateRefs.current.rawValue.length >= formatter.formats.length - 1;
@@ -47,7 +45,7 @@ const FormattedInput = ({ value, formatter, onChange, ...props }) => {
     * old unformatted value.
     */
     const injectionLength =
-      event.target.value.length - state.formattedValue.length;
+      event.target.value.length - formattedValue.length;
     const end =
       stateRefs.current.selectionStart === stateRefs.current.selectionEnd
         ? stateRefs.current.selectionStart + injectionLength
@@ -72,7 +70,7 @@ const FormattedInput = ({ value, formatter, onChange, ...props }) => {
     // Unformat the previous formatted value for injection
     // Using the relevant format string, strips away chars not marked with the formatChar
     const unformattedOldValue = unformat(formatter)(
-      state.formattedValue,
+      formattedValue,
       stateRefs.current.rawValue.length
     );
 
@@ -121,12 +119,7 @@ const FormattedInput = ({ value, formatter, onChange, ...props }) => {
           : stateRefs.current.selectionEnd;
 
     const formattedNewValue = format(formatter)(unformattedNewValue);
-    setState({
-      selectionStart: newFormattedCursorPosition,
-      selectionEnd: newFormattedCursorPosition,
-      rawValue: unformattedNewValue,
-      formattedValue: formattedNewValue,
-    });
+    setFormattedValue(formattedNewValue);
     // Apply the external onChange function to the raw underlying string
     // This is where the user generally updates the input value
     if (onChange) {

--- a/src/FormattedInput.js
+++ b/src/FormattedInput.js
@@ -17,12 +17,14 @@ export const createFormat = (formats, formatChar) => ({
 const FormattedInput = ({ value, formatter, onChange, ...props }) => {
   const inputEl = useRef(null);
   const [state, setState] = useState({
-    selectionStart: 0,
-    selectionEnd: 0,
-    rawValue: value,
-    delete: false,
     formattedValue: format(formatter)(value)
   });
+  const stateRefs = useRef({
+    selectionStart: 0,
+    selectionEnd: 0,
+    isDelete: false,
+    rawValue: '',
+  })
   useLayoutEffect(() => {
     // A lot of the work here is cursor manipulation
     if (inputEl.current && inputEl.current === document.activeElement) {
@@ -32,115 +34,116 @@ const FormattedInput = ({ value, formatter, onChange, ...props }) => {
       );
     }
   });
+  const handleChange = (event) => {
+    /* At the beginning of onChange, event.target.value is a concat of the previous formatted value
+    * and an unformatted injection at the start, end, or in the middle (maybe a deletion). To prepare 
+    * the unformatted value for the user's onChange, the formatted string and unformatted injection need
+    * to be separated, then unformat the formatted string, then insert (or delete) the injection from the
+    * old unformatted value.
+    */
+    const injectionLength =
+      event.target.value.length - state.formattedValue.length;
+    const end =
+      stateRefs.current.selectionStart === stateRefs.current.selectionEnd
+        ? stateRefs.current.selectionStart + injectionLength
+        : stateRefs.current.selectionEnd - 1;
+    const injection = event.target.value.substring(
+      stateRefs.current.selectionStart,
+      end
+    );
+    // Injection is the new unformatted piece of the input
+    // Need to find where to put it
+    const rawInjectionPointStart = formattedToUnformattedIndex(
+      stateRefs.current.selectionStart,
+      stateRefs.current.rawValue,
+      formatter
+    );
+    const rawInjectionPointEnd = formattedToUnformattedIndex(
+      stateRefs.current.selectionEnd,
+      stateRefs.current.rawValue,
+      formatter
+    );
+
+    // Unformat the previous formatted value for injection
+    // Using the relevant format string, strips away chars not marked with the formatChar
+    const unformattedOldValue = unformat(formatter)(
+      state.formattedValue,
+      stateRefs.current.rawValue.length
+    );
+
+    // Edit the previous unformatted value (either add, update or delete)
+    const injectIntoOldValue = inject(unformattedOldValue);
+    const deleteKeyPressed = stateRefs.current.isDelete;
+    const unformattedNewValue = deleteKeyPressed
+      ? rawInjectionPointStart === rawInjectionPointEnd
+        ? injectIntoOldValue(
+          rawInjectionPointStart - 1,
+          rawInjectionPointStart,
+          ""
+        )
+        : injectIntoOldValue(
+          rawInjectionPointStart,
+          rawInjectionPointEnd,
+          ""
+        )
+      : injectIntoOldValue(
+        rawInjectionPointStart,
+        rawInjectionPointEnd,
+        injection
+      );
+
+    const lengthDifference =
+      unformattedNewValue.length - stateRefs.current.rawValue.length;
+
+    const rawIndex =
+      formattedToUnformattedIndex(
+        stateRefs.current.selectionStart,
+        stateRefs.current.rawValue,
+        formatter
+      ) + lengthDifference;
+
+    // Find the new cursor position for the potential formatted value
+    // Applied by useLayoutEffect
+    const newFormattedCursorPosition =
+      stateRefs.current.selectionStart === stateRefs.current.selectionEnd
+        ? unformattedToFormattedIndex(
+          rawIndex,
+          unformattedNewValue,
+          formatter,
+          deleteKeyPressed
+        )
+        : deleteKeyPressed
+          ? stateRefs.current.selectionStart
+          : stateRefs.current.selectionEnd;
+
+    setState({
+      selectionStart: newFormattedCursorPosition,
+      selectionEnd: newFormattedCursorPosition,
+      rawValue: unformattedNewValue,
+      formattedValue: format(formatter)(unformattedNewValue),
+    });
+    // Apply the external onChange function to the raw underlying string
+    // This is where the user generally updates the input value
+    if (onChange) {
+      onChange(unformattedNewValue);
+    }
+  };
+
   return (
     <input
       {...props}
       ref={inputEl}
       value={format(formatter)(value)}
-      onKeyDown={event => {
-        // Keep track of the state of the input before onChange, including if user is hitting delete
-        setState({
-          rawValue: value,
+      onKeyDown={(event) => {
+        // Keep track of the state of the input before onChange
+        stateRefs.current = {
+          isDelete: event.key === "Backspace" || event.key === "Delete",
           selectionStart: event.target.selectionStart,
           selectionEnd: event.target.selectionEnd,
-          delete: event.key === "Backspace" || event.key === "Delete",
-          formattedValue: event.target.value
-        });
-      }}
-      onChange={event => {
-        /* At the beginning of onChange, event.target.value is a concat of the previous formatted value
-         * and an unformatted injection at the start, end, or in the middle (maybe a deletion). To prepare 
-         * the unformatted value for the user's onChange, the formatted string and unformatted injection need
-         * to be separated, then unformat the formatted string, then insert (or delete) the injection from the
-         * old unformatted value.
-         */
-        var injectionLength =
-          event.target.value.length - state.formattedValue.length;
-        const end =
-          state.selectionStart === state.selectionEnd
-            ? state.selectionStart + injectionLength
-            : state.selectionEnd - 1;
-        const injection = event.target.value.substring(
-          state.selectionStart,
-          end
-        );
-        // Injection is the new unformatted piece of the input
-        // Need to find where to put it
-        const rawInjectionPointStart = formattedToUnformattedIndex(
-          state.selectionStart,
-          state.rawValue,
-          formatter
-        );
-        const rawInjectionPointEnd = formattedToUnformattedIndex(
-          state.selectionEnd,
-          state.rawValue,
-          formatter
-        );
-
-        // Unformat the previous formatted value for injection
-        // Using the relevant format string, strips away chars not marked with the formatChar
-        const unformattedOldValue = unformat(formatter)(
-          state.formattedValue,
-          state.rawValue.length
-        );
-
-        // Edit the previous unformatted value (either add, update or delete)
-        const injectIntoOldValue = inject(unformattedOldValue);
-        const unformattedNewValue = state.delete
-          ? rawInjectionPointStart === rawInjectionPointEnd
-            ? injectIntoOldValue(
-                rawInjectionPointStart - 1,
-                rawInjectionPointStart,
-                ""
-              )
-            : injectIntoOldValue(
-                rawInjectionPointStart,
-                rawInjectionPointEnd,
-                ""
-              )
-          : injectIntoOldValue(
-              rawInjectionPointStart,
-              rawInjectionPointEnd,
-              injection
-            );
-
-        const lengthDifference =
-          unformattedNewValue.length - state.rawValue.length;
-
-        const rawIndex =
-          formattedToUnformattedIndex(
-            state.selectionStart,
-            state.rawValue,
-            formatter
-          ) + lengthDifference;
-
-        // Find the new cursor position for the potential formatted value
-        // Applied by useLayoutEffect
-        const newFormattedCursorPosition =
-          state.selectionStart == state.selectionEnd
-            ? unformattedToFormattedIndex(
-                rawIndex,
-                unformattedNewValue,
-                formatter,
-                state.delete
-              )
-            : state.delete
-            ? state.selectionStart
-            : state.selectionEnd;
-
-        setState({
-          selectionStart: newFormattedCursorPosition,
-          selectionEnd: newFormattedCursorPosition,
-          rawValue: state.rawValue,
-          delete: false,
-          formattedValue: state.formattedValue
-        });
-        // Apply the external onChange function to the raw underlying string
-        // This is where the user generally updates the input value
-        if (onChange) {
-          onChange(unformattedNewValue);
+          rawValue: value,
         }
       }}
+      onChange={handleChange}
     />
   );
 };


### PR DESCRIPTION
## Description
When attempting to pay on Web Checkout using mobile Chrome browsers, autofill on the `/customer-information` screen is not properly populating the Zip Code and Phone Number fields. Both of these are using this `formatted-input` library under the hood.

[WCHK-1410](https://citybase.atlassian.net/jira/software/c/projects/WEB/boards/210?selectedIssue=WCHK-1410)

This PR addresses this problem by keeping the spirit of the original code and its comments, but moving most of the state from a `useState` hook, to a `useRef` value. 

## Changes
- [x] Replace `setState` call occurring in `onKeyDown` event with setting the value of the ref. This prevents a duplicate render caused by the original `setState` implementation here. We now only call `setState` once from `onChange`. 
- [x] Extract inline `onChange` logic to a `handleChange` function

## Risk
The risk is arguably none for this PR because it is a library version update but I want to call out that once this is published, someone could inadvertently pull it into a CB Components upgrade, then add it to their application because this package is set to ["^1.0.0"](https://github.com/CityBaseInc/cb-components/blob/master/package.json#L86C24-L86C32). 

The real risk comes after this is added to a CB components version and Navigate upgrades that package. 

Navigate is the only frontend I can see that is using CB Components which implement `formatted-input`. This is controlled by the `formatter` prop being passed to FormInput. The impacted components we will need to regression test to mitigate risk are:

- AddressForm
- PaymentFormCard
- PartialAmountForm (which renders PartialAmountField)
- PhoneForm

At worst, this could block Checkout forms from being able to be completed, disabling the ability to complete payments. Rollback would be simple but would involve 3 PRs (revert in formatted-input, cb-components, NFE).

## Testing
This is live at https://cityville-serve.uat.cityba.se/login

I have regression tested the components in the Risk section rendered within Navigate myself, and all changes seem positive. Though I definitely would like someone else more familiar with the product to test it too.

## Code of Conduct
https://github.com/CityBaseInc/formatted-input/blob/master/CODE_OF_CONDUCT.md

## Screenshots


https://github.com/user-attachments/assets/d9aa37c1-7eb4-49fe-bfe9-f8d69910775e



[WCHK-1410]: https://citybase.atlassian.net/browse/WCHK-1410?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ